### PR TITLE
Use Microsoft Hosted agent for RunDependabot job

### DIFF
--- a/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
+++ b/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
@@ -8,10 +8,10 @@ parameters:
 stages:
 - stage: Dependabot
   condition: eq(variables['Build.Reason'], 'Schedule')
-  pool:
-    vmImage: ubuntu-latest
   jobs:
   - job: RunDependabot
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - checkout: self
       persistCredentials: true


### PR DESCRIPTION
This job runs a docker container so can't be ran on self hosted agent. Moved this from stage so that MergePRs job can run on self hosted agent.