### PR TITLE
Downgrade GitVersion spec from 6 to 5

### DIFF
--- a/AzureDevOpsTemplates/Build/StepTemplates/dotnetcore-build-notests.yml
+++ b/AzureDevOpsTemplates/Build/StepTemplates/dotnetcore-build-notests.yml
@@ -21,7 +21,7 @@ steps:
 - task: gitversion/setup@3.0.0
   displayName: Install GitVersion
   inputs:
-    versionSpec: 6.x
+    versionSpec: 5.x
 
 - task: gitversion/execute@3.0.0
   displayName: gitversion/execute

--- a/AzureDevOpsTemplates/Build/StepTemplates/dotnetcore-build.yml
+++ b/AzureDevOpsTemplates/Build/StepTemplates/dotnetcore-build.yml
@@ -23,7 +23,7 @@ steps:
 - task: gitversion/setup@3.0.0
   displayName: Install GitVersion
   inputs:
-    versionSpec: 6.x
+    versionSpec: 5.x
 
 - task: gitversion/execute@3.0.0
   displayName: gitversion/execute


### PR DESCRIPTION
Behaviour has changed significantly in 6 and it's not currently obvious how to match previous settings