### PR TITLE
Bump dependabot from version 1 to 2

### DIFF
--- a/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
+++ b/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
@@ -2,8 +2,6 @@ parameters:
   ScheduleName:
   SlackApiUrl:
   SourceFolder:
-  DependabotImageTag: ''
-  EnableDebug: false
   GitEmail: ''
   GitUsername: ''
   RunDependabotManually: false
@@ -45,14 +43,10 @@ stages:
         SourceFolder: ${{ parameters.SourceFolder }}
         Contents: '**/dependabot.yml'
         TargetFolder: $(Build.SourcesDirectory)/
-    - task: dependabot@1
+    - task: dependabot@2
       condition: or(and(eq(variables['CheckScheduleName.RunDependabot'], 'true'), le(variables['System.JobAttempt'], 1), succeeded()), ${{ parameters.RunDependabotManually }})
       inputs:
         useConfigFile: true
-        ${{ if gt(length(parameters.DependabotImageTag), 0) }}:
-          dockerImageTag: ${{ parameters.DependabotImageTag }}
-        ${{ if eq(parameters.EnableDebug, true)  }}:
-          extraEnvironmentVariables: 'EXCON_DEBUG=1'
   - job: MergePRs
     condition: or(and(eq(variables['RunDependabot'], 'true'), succeeded()), ${{ parameters.RunMergePRManually }})
     variables:


### PR DESCRIPTION
* Remove DependabotImageTag input - deprecated
* Remove EnableDebug - the inputs this requires are now deprecated, debug enabled with System.Debug pipeline variable