### PR TITLE
Delay dependabot merge job and auto-complete the staging PR

### DIFF
--- a/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
+++ b/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
@@ -9,6 +9,9 @@ parameters:
   DependabotExperiments: 'none'
   RunDependabotManually: false
   RunMergePRManually: false
+  # Agentless delay between raising the dependabot PRs and merging them, giving
+  # the PR validation builds time to complete on the single self-hosted agent
+  MergeDelayMinutes: 120
 
 stages:
 - stage: Dependabot
@@ -51,6 +54,15 @@ stages:
       inputs:
         dependabotCliPackage: ${{ format('github.com/dependabot/cli/cmd/dependabot@{0}',  parameters.DependabotCliVersion ) }}
         experiments: ${{ parameters.DependabotExperiments }}
+  - job: WaitForBuilds
+    dependsOn: RunDependabot
+    condition: or(and(eq(dependencies.RunDependabot.outputs['CheckScheduleName.RunDependabot'], 'true'), succeeded()), ${{ and(parameters.RunDependabotManually, parameters.RunMergePRManually) }})
+    pool: server
+    timeoutInMinutes: 0
+    steps:
+    - task: Delay@1
+      inputs:
+        delayForMinutes: ${{ parameters.MergeDelayMinutes }}
   - job: MergePRs
     condition: or(and(eq(variables['RunDependabot'], 'true'), succeeded()), ${{ parameters.RunMergePRManually }})
     variables:
@@ -58,7 +70,9 @@ stages:
     ${{ if and(not(parameters.RunDependabotManually), parameters.RunMergePRManually) }}:
       dependsOn: []
     ${{ else }}:
-      dependsOn: RunDependabot
+      dependsOn:
+      - RunDependabot
+      - WaitForBuilds
     timeoutInMinutes: 0
     steps:
     - checkout: self
@@ -84,6 +98,7 @@ stages:
             GitUsername = "${{ parameters.GitUsername }}"
             SourceCodeRootDirectory = "${{ parameters.SourceFolder }}"
             UseGitHiresMerge = $true
+            SetAutoComplete = $true
           }
           $PullRequest = Merge-MultiplePullRequest @Params
           if ($PullRequest) {
@@ -96,5 +111,5 @@ stages:
       inputs:
         targetType: 'filePath'
         filePath: gandt-devops/PSScripts/Send-SlackMessage.ps1
-        arguments: -Emoji ":man-lifting-weights:" -FallBackMessage "Dependabot PR $(PullRequestTitle) raised" -MarkdownMessage "Dependabot PR $(PullRequestTitle) raised" -MessageTitle "Weekly Dependabot Update" -SlackApiUrl "${{ parameters.SlackApiUrl }}"
+        arguments: -Emoji ":man-lifting-weights:" -FallBackMessage "Dependabot PR $(PullRequestTitle) raised and set to auto-complete" -MarkdownMessage "Dependabot PR $(PullRequestTitle) raised and set to auto-complete" -MessageTitle "Weekly Dependabot Update" -SlackApiUrl "${{ parameters.SlackApiUrl }}"
         pwsh: true


### PR DESCRIPTION
## Changes to `dependabot-run.yml`

- New agentless `WaitForBuilds` server job (Delay task, parameterized `MergeDelayMinutes`, default 120) between `RunDependabot` and `MergePRs`. The single self-hosted agent stays free to run the PR validation builds during the wait. Skipped on the `RunMergePRManually`-only path (merge runs immediately, as today); active when both manual parameters are set.
- `MergePRs` passes `-SetAutoComplete` to `Merge-MultiplePullRequest`: the staging `DEP-*` PR auto-completes (squash, delete source branch) once its full build passes. The `DeployToWww` approval gate remains the human checkpoint before production.
- Slack message now reads "raised and set to auto-complete".

Requires `gandt-azure-devops-tools` >= 1.6.0 (consumer pin bump follows in the grahamandtonic repo).

Fixes the weekly dependabot run merging nothing because `MergePRs` ran ~2 minutes after the PRs were raised, while their validation builds were still queued behind it on the same agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JuDaKcXrEsRs4bVS23unt