### PR TITLE
Allow pinning the dependabot updater image tag

### DIFF
--- a/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
+++ b/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
@@ -6,6 +6,11 @@ parameters:
   GitUsername:
   DefaultBranchName: 'refs/heads/master'
   DependabotCliVersion: 'latest'
+  # Tag of the ghcr.io/dependabot/dependabot-updater-{ecosystem} image the
+  # dependabot@2 task runs. Defaults to 'latest'; pin to a known-good tag when
+  # a 'latest' image is incompatible with the installed extension (e.g. the
+  # ZodError 400 on data.reason from a NuGet updater newer than the task schema).
+  DependabotUpdaterImageTag: 'latest'
   DependabotExperiments: 'none'
   RunDependabotManually: false
   RunMergePRManually: false
@@ -53,6 +58,7 @@ stages:
       condition: or(and(eq(variables['CheckScheduleName.RunDependabot'], 'true'), le(variables['System.JobAttempt'], 1), succeeded()), ${{ parameters.RunDependabotManually }})
       inputs:
         dependabotCliPackage: ${{ format('github.com/dependabot/cli/cmd/dependabot@{0}',  parameters.DependabotCliVersion ) }}
+        dependabotUpdaterImage: 'ghcr.io/dependabot/dependabot-updater-{ecosystem}:${{ parameters.DependabotUpdaterImageTag }}'
         experiments: ${{ parameters.DependabotExperiments }}
   - job: WaitForBuilds
     dependsOn: RunDependabot

--- a/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
+++ b/AzureDevOpsTemplates/Build/StageTemplates/dependabot-run.yml
@@ -5,7 +5,6 @@ parameters:
   GitEmail:
   GitUsername:
   DefaultBranchName: 'refs/heads/master'
-  DependabotCliVersion: 'latest'
   # Tag of the ghcr.io/dependabot/dependabot-updater-{ecosystem} image the
   # dependabot@2 task runs. Defaults to 'latest'; pin to a known-good tag when
   # a 'latest' image is incompatible with the installed extension (e.g. the
@@ -57,7 +56,6 @@ stages:
     - task: dependabot@2
       condition: or(and(eq(variables['CheckScheduleName.RunDependabot'], 'true'), le(variables['System.JobAttempt'], 1), succeeded()), ${{ parameters.RunDependabotManually }})
       inputs:
-        dependabotCliPackage: ${{ format('github.com/dependabot/cli/cmd/dependabot@{0}',  parameters.DependabotCliVersion ) }}
         dependabotUpdaterImage: 'ghcr.io/dependabot/dependabot-updater-{ecosystem}:${{ parameters.DependabotUpdaterImageTag }}'
         experiments: ${{ parameters.DependabotExperiments }}
   - job: WaitForBuilds


### PR DESCRIPTION
Two changes to the `dependabot-run.yml` stage template, in separate commits.

## 1. Add `DependabotUpdaterImageTag` parameter (pin the updater image)
The paklo `dependabot@2` task (v2.68.2) runs the official `ghcr.io/dependabot/dependabot-updater-{ecosystem}` image at `:latest`. When that image is newer than the task's API-server Zod schema, the NuGet updater sends a `data.reason` value the task rejects → **ZodError 400**, failing the whole run. There is no newer extension to upgrade to, so pinning the updater image to a known-good tag is the only self-service fix.

New parameter `DependabotUpdaterImageTag` (default `latest`) is wired to the task's `dependabotUpdaterImage` input. Default `latest` reproduces the task's existing default → **no change** for consumers that don't set it. Pin by setting it in a consumer pipeline (in code) or at manual queue time.

## 2. Remove dead `dependabotCliPackage` input
The v2 task has no `dependabotCliPackage` input (that belonged to the older CLI-based task, which used `go install .../cli`). The input and its `DependabotCliVersion` parameter were silently ignored, so both are removed.

## Breaking-change note for consumers
Consumers pin `gandt-devops` by tag, so this is **non-breaking until they bump** to a tag containing this change. When they bump:
- **Must stop passing** `DependabotCliVersion` to this template (parameter no longer exists → passing it errors).
- Optionally pass `DependabotUpdaterImageTag` to pin the updater image.

Consumers: `grahamandtonic` and `gandt-shared` dependabot pipelines. Follow-up (separate session) bumps the `grahamandtonic` pin to the tag cut from this PR, drops `DependabotCliVersion`, and exposes `DependabotUpdaterImageTag` as a manual-run parameter.

> Note: this branch is rebased on `fd7c077` (the P2 merge-delay / staging-PR autocomplete change), so a consumer bumping to this tag also picks up P2 — which requires `gandt-azure-devops-tools >= 1.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)